### PR TITLE
Add support for mixpanel.people.increment

### DIFF
--- a/lib/angulartics-mixpanel.js
+++ b/lib/angulartics-mixpanel.js
@@ -33,6 +33,13 @@ angular.module('angulartics.mixpanel', ['angulartics'])
     $analyticsProvider.registerEventTrack(function (action, properties) {
       mixpanel.track(action, properties);
     });
+    $analyticsProvider.registerIncrementProperty(function (property, value) {
+      if (typeof value === 'undefined') {
+        mixpanel.people.increment(property);
+      } else {
+        mixpanel.people.increment(property, value);
+      }
+    });
     $analyticsProvider.registerUserTimings(function (properties, action) {
       mixpanel.time_event(action);
     });


### PR DESCRIPTION
Mixpanel allows for the people.increment function to be used without the second argument, which defaults to 1. 
