### PR TITLE
Update links to point to the repo of angulartics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![NPM version][npm-image]][npm-url] [![NPM downloads][npm-downloads-image]][npm-downloads-url] [![Bower version][bower-image]][bower-url] [![Dependencies status][dep-status-image]][dep-status-url] [![MIT license][license-image]][license-url] [![Join the Slack chat][slack-image]][slack-url]
 
-Mixpanel plugin for [Angulartics](http://github.com/luisfarzati/angulartics).
+Mixpanel plugin for [Angulartics](https://github.com/angulartics/angulartics).
 
 ## Install
 
-First make sure you've read installation and setup instructions for [Angulartics](https://github.com/luisfarzati/angulartics#install).
+First make sure you've read installation and setup instructions for [Angulartics](https://github.com/angulartics/angulartics#install).
 
 Then you can install this package either with `npm` or with `bower`.
 


### PR DESCRIPTION
Think it is useful to update the links, although I learned the history of the projects with previous links
