### PR TITLE
User timings function does not work with parameters current way around - fixed

### DIFF
--- a/lib/angulartics-mixpanel.js
+++ b/lib/angulartics-mixpanel.js
@@ -40,7 +40,7 @@ angular.module('angulartics.mixpanel', ['angulartics'])
         mixpanel.people.increment(property, value);
       }
     });
-    $analyticsProvider.registerUserTimings(function (properties, action) {
+    $analyticsProvider.registerUserTimings(function (action, properties) {
       mixpanel.time_event(action);
     });
   });


### PR DESCRIPTION
Must be in this order to interact properly with angulartics-google-analytics library if tagging for both sites
