### PR TITLE
Providing analytics function for cookie.clear method in mix panel

### DIFF
--- a/lib/angulartics-mixpanel.js
+++ b/lib/angulartics-mixpanel.js
@@ -43,6 +43,9 @@ angular.module('angulartics.mixpanel', ['angulartics'])
     $analyticsProvider.registerUserTimings(function (properties, action) {
       mixpanel.time_event(action);
     });
+    $analyticsProvider.registerCookiesClear(function () {
+      mixpanel.cookie.clear();
+    });
   });
 
 }]);


### PR DESCRIPTION
takes no arguments as input
