### PR TITLE
fix package.json as utf 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "angulartics-mixpanel",
   "version": "0.1.3",
   "description": "Mixpanel plugin for Angulartics",


### PR DESCRIPTION
fix encoding of file (this breaks yarn installations and CI builds)

- Change encoding of package.json from utf-8 [with DOM] to utf-8