### PR TITLE
bump angulartics bower dependency to ^1.1.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "angulartics-mixpanel",
   "main": "./lib/angulartics-mixpanel.js",
   "dependencies": {
-    "angulartics": "^1.0.0"
+    "angulartics": "^1.1.0"
   },
   "ignore": [
     "**/.*",


### PR DESCRIPTION
ref #25 

when following the instructions to install `angulartics` implicitly by installing `angulartics-mixpanel` and trusting it to install its dependencies, we get a version of `angulartics` that does not yet support `incrementProperty`, which was added in [v1.1.0](https://github.com/angulartics/angulartics/releases/tag/1.1.0)

